### PR TITLE
chore: gitignore .vscode and .claude directories for supply chain protection

### DIFF
--- a/.github/workflows/block-ide-dirs.yml
+++ b/.github/workflows/block-ide-dirs.yml
@@ -1,5 +1,7 @@
 name: Block IDE/agent config directories
 on: [pull_request, push]
+permissions:
+  contents: read
 jobs:
   block-ide-dirs:
     runs-on: ubuntu-latest

--- a/.github/workflows/block-ide-dirs.yml
+++ b/.github/workflows/block-ide-dirs.yml
@@ -1,0 +1,14 @@
+name: Block IDE/agent config directories
+on: [pull_request, push]
+jobs:
+  block-ide-dirs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject .vscode and .claude directories
+        run: |
+          if git ls-files .vscode .claude | grep -q .; then
+            echo "::error::Supply chain risk: .vscode/ or .claude/ files must not be committed"
+            git ls-files .vscode .claude
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,5 @@ argocd
 butane
 output/
 *.tar.gz
+.vscode/
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.vscode/` and `.claude/` to `.gitignore` to prevent supply chain attacks via committed IDE/agent config directories

## Context
Supply chain attacks have been observed using `.vscode` and `.claude` directories committed to GitHub repos to execute arbitrary code when developers clone and open projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)