### PR TITLE
fix: replace pull_request_target with pull_request in commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,7 @@
 name: "Lint PR title"
 # Can run on public GH actions runner
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -25,8 +25,6 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        ref: ${{ github.event.pull_request.base.sha }}
 
     - name: Install dependencies
       run: npm install @commitlint/cli @commitlint/config-conventional


### PR DESCRIPTION
## Summary
- Replaces `pull_request_target` trigger with `pull_request` in the commitlint workflow
- Removes the now-unnecessary explicit `ref: base.sha` checkout
- `pull_request_target` grants write permissions and secrets access to workflows triggered by external PRs, which GitHub Security flags as dangerous
- Since this workflow only lints the PR title, the safer `pull_request` trigger is sufficient

## Test plan
- [ ] Verify GitHub no longer flags this workflow as dangerous
- [ ] Open a test PR and confirm commitlint still validates the PR title
- [ ] Verify PRs with non-conventional titles are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)