### PR TITLE
chore: group dependabot updates into single PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      all-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     # Look for the Dockerfile or Containerfile in the root directory
     directory: "/"
@@ -21,3 +25,7 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      all-docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `groups` configuration to both `github-actions` and `docker` package ecosystems in Dependabot
- All dependency updates within each ecosystem will now be rolled up into a single PR instead of individual PRs per dependency

## Test plan
- [ ] After merge, verify Dependabot creates grouped PRs on its next scheduled run
- [ ] Confirm both `all-actions` and `all-docker` groups appear in Dependabot's behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)